### PR TITLE
LV2: Param: Save full state (sample + params)

### DIFF
--- a/src/padthv1.cpp
+++ b/src/padthv1.cpp
@@ -607,7 +607,7 @@ struct padthv1_glide
 	{
 		m_frames = frames;
 
-		if (m_frames > 0) {
+		if (m_frames > 0 && m_last > 0.0f) {
 			m_freq = m_last - freq;
 			m_step = m_freq / float(m_frames);
 		} else {

--- a/src/padthv1.lv2/padthv1.ttl
+++ b/src/padthv1.lv2/padthv1.ttl
@@ -31,7 +31,6 @@
 	lv2:requiredFeature lv2urid:map, lv2worker:schedule ;
 	lv2:optionalFeature lv2:hardRTCapable ;
 	lv2:extensionData lv2state:interface, lv2worker:interface ;
-	lv2ui:ui padthv1_lv2:ui_x11, padthv1_lv2:ui_external ;
 	lv2patch:writable padthv1_lv2:P201_TUNING_ENABLED,
 		padthv1_lv2:P202_TUNING_REF_PITCH,
 		padthv1_lv2:P203_TUNING_REF_NOTE,

--- a/src/padthv1.lv2/padthv1_ui.ttl
+++ b/src/padthv1.lv2/padthv1_ui.ttl
@@ -1,8 +1,13 @@
 @prefix lv2:     <http://lv2plug.in/ns/lv2core#> .
 @prefix lv2ui:   <http://lv2plug.in/ns/extensions/ui#> .
 
+@prefix padthv1_lv2: <http://padthv1.sourceforge.net/lv2#> .
+
+<http://padthv1.sourceforge.net/lv2>
+	lv2ui:ui padthv1_lv2:ui_x11, padthv1_lv2:ui_external .
+
 <http://padthv1.sourceforge.net/lv2#ui>
-	a lv2ui:Qt5UI ;
+	a lv2ui:Qt6UI ;
 	lv2:requiredFeature <http://lv2plug.in/ns/ext/instance-access> ;
 	lv2ui:binary <padthv1.so> .
 

--- a/src/padthv1widget_lv2.cpp
+++ b/src/padthv1widget_lv2.cpp
@@ -1,7 +1,7 @@
 // padthv1widget_lv2.cpp
 //
 /****************************************************************************
-   Copyright (C) 2012-2020, rncbc aka Rui Nuno Capela. All rights reserved.
+   Copyright (C) 2012-2021, rncbc aka Rui Nuno Capela. All rights reserved.
 
    This program is free software; you can redistribute it and/or
    modify it under the terms of the GNU General Public License
@@ -41,10 +41,10 @@
 #endif
 #endif
 
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-#define CONFIG_PLUGINSDIR CONFIG_LIBDIR "/qt4/plugins"
-#else
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 #define CONFIG_PLUGINSDIR CONFIG_LIBDIR "/qt5/plugins"
+#else
+#define CONFIG_PLUGINSDIR CONFIG_LIBDIR "/qt6/plugins"
 #endif
 
 

--- a/src/padthv1widget_lv2.h
+++ b/src/padthv1widget_lv2.h
@@ -1,7 +1,7 @@
 // padthv1widget_lv2.h
 //
 /****************************************************************************
-   Copyright (C) 2012-2020, rncbc aka Rui Nuno Capela. All rights reserved.
+   Copyright (C) 2012-2021, rncbc aka Rui Nuno Capela. All rights reserved.
 
    This program is free software; you can redistribute it and/or
    modify it under the terms of the GNU General Public License


### PR DESCRIPTION
Before, PadthV1 will only store sample data into plugin state. This can cause a problem: presets won't be loaded properly (either nothing was loaded, or other unrelated preset was restored).

So the best choice is to let PadthV1 store anything of what a preset should have. Considering that accessing external presets has no problem, I just implement codes from `padthv1_param::loadPreset()` and `padthv1_param::savePreset()`.

NOTE: Only commit 5256118 related to this improvement. 