### PR TITLE
LV2: Fix: Win32 UI not shown when CONFIG_LV2_UI_X11=0

### DIFF
--- a/src/padthv1_lv2ui.cpp
+++ b/src/padthv1_lv2ui.cpp
@@ -456,15 +456,14 @@ LV2_SYMBOL_EXPORT const LV2UI_Descriptor *lv2ui_descriptor ( uint32_t index )
 	if (index == 1)
 		return &padthv1_lv2ui_x11_descriptor;
 	else
+#elif defined(CONFIG_LV2_UI_WINDOWS)
+	if (index == 1)
+		return &padthv1_lv2ui_windows_descriptor;
+	else
 #endif
 #ifdef CONFIG_LV2_UI_EXTERNAL
 	if (index == 2)
 		return &padthv1_lv2ui_external_descriptor;
-	else
-#endif
-#ifdef CONFIG_LV2_UI_WINDOWS
-	if (index == 3)
-		return &padthv1_lv2ui_windows_descriptor;
 	else
 #endif
 	return nullptr;


### PR DESCRIPTION
Since Win32-specific options in CMakeLists.txt has been separated, CONFIG_LV2_UI_X11 won't be applied on Windows. But even though CONFIG_LV2_UI_WINDOWS=1, once CONFIG_LV2_UI_X11 is off, UI won't shown.

This is because of a mistake in src/synthv1_lv2ui.cpp, function lv2ui_descriptor().

LV2 enumerates all possible UI descriptors:
- Index 0: Generic UI
- Index 1: Qt-based UI
- Index 2: External UI

I had mistaken that the Win32 UI could be Index 3, and X11 UI could only be Index 1. But actually both X11 and Win32 Qt UI should be refered as Index 1.

Consequently, in my wrong implementation, only if CONFIG_LV2_UI_X11=1 can make lv2ui_descriptor() enumrates to Index 3, then load descriptor for Win32 UI. If CONFIG_LV2_UI_X11=0, lv2ui_descriptor() will stop at Index 1, so Win32 descriptor is never loaded.

As only one of CONFIG_LV2_UI_X11 or CONFIG_LV2_UI_WINDOWS could be activated normally, simply reform the preprocessor statements to check which code shall lv2ui_descriptor() execute on Index 1.